### PR TITLE
implement asynchronous reading of extra information

### DIFF
--- a/gps_ubloxTypes.hpp
+++ b/gps_ubloxTypes.hpp
@@ -15,8 +15,9 @@ namespace gps_ublox {
          */
         struct MessageRates {
             uint8_t nav_pvt = 1;
-            uint8_t nav_sig = 0;
-            uint8_t mon_rf = 0;
+            uint8_t nav_sig = 10;
+            uint8_t nav_sat = 10;
+            uint8_t mon_rf = 10;
         };
 
         /**

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -63,12 +63,14 @@ bool Task::configureHook()
 
     iodrivers_base::ConfigureGuard guard(this);
     mDriver = std::unique_ptr<gps_ublox::Driver>(new Driver());
-    if (!_io_port.get().empty())
+    if (!_io_port.get().empty()) {
         mDriver->openURI(_io_port.get());
+    }
     setDriver(mDriver.get());
 
-    if (! TaskBase::configureHook())
+    if (! TaskBase::configureHook()) {
         return false;
+    }
 
     loadConfiguration();
 
@@ -77,8 +79,9 @@ bool Task::configureHook()
 }
 bool Task::startHook()
 {
-    if (! TaskBase::startHook())
+    if (! TaskBase::startHook()) {
         return false;
+    }
     return true;
 }
 void Task::updateHook()
@@ -89,9 +92,12 @@ void Task::updateHook()
 template<typename T>
 T may_invalidate(T const& value)
 {
-    if (value == T::Zero())
+    if (value == T::Zero()) {
         return T::Ones() * base::unknown<double>();
-    else return value;
+    }
+    else {
+        return value;
+    }
 }
 
 base::samples::RigidBodyState Task::convertToRBS(const gps_ublox::GPSData &data) const {


### PR DESCRIPTION
Synchronous reading takes ~4s, which (obviously) interferes a lot
with the normal gps solution output.

Depends on:
- [x] https://github.com/tidewise/drivers-gps_ublox/pull/6