### PR TITLE
fix: adapt to non-backward-compatible changes in driver library

### DIFF
--- a/gps_ublox.orogen
+++ b/gps_ublox.orogen
@@ -10,10 +10,10 @@ using_task_library "iodrivers_base"
 
 using_library "gps_ublox"
 import_types_from "gps_ubloxTypes.hpp"
-import_types_from "gps_ublox/Driver.hpp"
+import_types_from "gps_ublox/cfg.hpp"
 import_types_from "gps_ublox/SignalInfo.hpp"
 import_types_from "gps_ublox/RFInfo.hpp"
-import_types_from "gps_ublox/GPSData.hpp"
+import_types_from "gps_ublox/PVT.hpp"
 
 task_context "Task", subclasses: "iodrivers_base::Task" do
     needs_configuration
@@ -22,7 +22,7 @@ task_context "Task", subclasses: "iodrivers_base::Task" do
     property "utm_parameters", "gps_base/UTMConversionParameters"
 
     # The device port used to communicate with this component
-    property "device_port", "gps_ublox/Driver/DevicePort", "PORT_USB"
+    property "device_port", "gps_ublox/DevicePort", "PORT_USB"
 
     # Message output rates
     property "msg_rates", "gps_ublox/configuration/MessageRates"

--- a/gps_ublox.orogen
+++ b/gps_ublox.orogen
@@ -1,43 +1,43 @@
 # frozen_string_literal: true
 
-name 'gps_ublox'
+name "gps_ublox"
 
-import_types_from 'std'
-import_types_from 'base'
-import_types_from 'iodrivers_base'
-import_types_from 'gps_base'
-using_task_library 'iodrivers_base'
+import_types_from "std"
+import_types_from "base"
+import_types_from "iodrivers_base"
+import_types_from "gps_base"
+using_task_library "iodrivers_base"
 
-using_library 'gps_ublox'
-import_types_from 'gps_ubloxTypes.hpp'
-import_types_from 'gps_ublox/Driver.hpp'
-import_types_from 'gps_ublox/SignalInfo.hpp'
-import_types_from 'gps_ublox/RFInfo.hpp'
-import_types_from 'gps_ublox/GPSData.hpp'
+using_library "gps_ublox"
+import_types_from "gps_ubloxTypes.hpp"
+import_types_from "gps_ublox/Driver.hpp"
+import_types_from "gps_ublox/SignalInfo.hpp"
+import_types_from "gps_ublox/RFInfo.hpp"
+import_types_from "gps_ublox/GPSData.hpp"
 
-task_context 'Task', subclasses: 'iodrivers_base::Task' do
+task_context "Task", subclasses: "iodrivers_base::Task" do
     needs_configuration
 
     # Lat/Lon to UTM convertion configuration
-    property 'utm_parameters', 'gps_base/UTMConversionParameters'
+    property "utm_parameters", "gps_base/UTMConversionParameters"
 
     # The device port used to communicate with this component
-    property 'device_port', 'gps_ublox/Driver/DevicePort', 'PORT_USB'
+    property "device_port", "gps_ublox/Driver/DevicePort", "PORT_USB"
 
     # Message output rates
-    property 'msg_rates', 'gps_ublox/configuration/MessageRates'
+    property "msg_rates", "gps_ublox/configuration/MessageRates"
 
     # Device's dometer configuration
-    property 'odometer_configuration', 'gps_ublox/configuration/Odometer'
+    property "odometer_configuration", "gps_ublox/configuration/Odometer"
 
     # Navigation solution's configuration
-    property 'navigation_configuration', 'gps_ublox/configuration/Navigation'
+    property "navigation_configuration", "gps_ublox/configuration/Navigation"
 
-    output_port 'pose_samples', 'base/samples/RigidBodyState'
-    output_port 'gps_solution', 'gps_base/Solution'
-    output_port 'satellite_info', 'gps_base/SatelliteInfo'
-    output_port 'signal_info', 'gps_ublox/SignalInfo'
-    output_port 'rf_info', 'gps_ublox/RFInfo'
+    output_port "pose_samples", "base/samples/RigidBodyState"
+    output_port "gps_solution", "gps_base/Solution"
+    output_port "satellite_info", "gps_base/SatelliteInfo"
+    output_port "signal_info", "gps_ublox/SignalInfo"
+    output_port "rf_info", "gps_ublox/RFInfo"
 
     fd_driven
 end

--- a/gps_ubloxTypes.hpp
+++ b/gps_ubloxTypes.hpp
@@ -28,7 +28,7 @@ namespace gps_ublox {
             bool low_speed_course_over_ground_filter = true;
             bool output_low_pass_filtered_velocity = true;
             bool output_low_pass_filtered_heading = true;
-            Driver::OdometerProfile odometer_profile = Driver::ODOM_SWIMMING;
+            OdometerProfile odometer_profile = ODOM_SWIMMING;
             uint8_t upper_speed_limit_for_heading_filter = 5;
             uint8_t max_position_accuracy_for_low_speed_heading_filter = 5;
             uint8_t velocity_low_pass_filter_level = 1;
@@ -40,11 +40,10 @@ namespace gps_ublox {
          */
         struct Navigation {
 
-            base::Time position_measurement_period =
-                base::Time::fromMilliseconds(1000);
+            base::Time position_measurement_period = base::Time::fromMilliseconds(1000);
             uint16_t measurements_per_solution_ratio = 1;
-            UBX::TimeSystem time_system = UBX::GPS;
-            UBX::DynamicModel dynamic_model = UBX::SEA;
+            MeasurementRefTime measurement_ref_time = MEASUREMENT_REF_TIME_GPS;
+            DynamicModel dynamic_model = DYNAMIC_MODEL_SEA;
 
             /** Speed below which the receiver is considered static (in m/s)
              *
@@ -53,7 +52,7 @@ namespace gps_ublox {
             float speed_threshold = 0;
 
             /** Distance above which GNSSbased stationary motion is exit (m) */
-            int static_hold_distance_threshold;
+            int static_hold_distance_threshold = 0;
         };
     }
 }

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -102,9 +102,9 @@ namespace gps_ublox{
         void cleanupHook();
 
         void loadConfiguration();
-        base::samples::RigidBodyState convertToRBS(const GPSData &data) const;
+        base::samples::RigidBodyState convertToRBS(const PVT &data) const;
         gps_base::SatelliteInfo convertToBaseSatelliteInfo(const SatelliteInfo &data) const;
-        gps_base::Solution convertToBaseSolution(const GPSData &data) const;
+        gps_base::Solution convertToBaseSolution(const PVT &data) const;
     };
 }
 


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/tidewise/drivers-gps_ublox/pull/7

* renamed GPSData into PVT
* moved "public" configuration enums to gps_ublox instead of under Driver